### PR TITLE
fixes bug with extra spaces in imports

### DIFF
--- a/src/Arion/Types.hs
+++ b/src/Arion/Types.hs
@@ -64,13 +64,8 @@ toTestFile filePath content = let importLines = getImports content
 
 getImports :: FileContent -> [String]
 getImports fileContent = let importLines = getAllTextMatches $ fileContent =~ "import.*" :: [String]
-                             imports = map (importedModule . splitOn " ") importLines
+                             imports = map ((\(_:x:_) -> x) . filter (not . (`elem` ["","qualified"])) . splitOn " ") importLines
                          in imports
-
-importedModule :: [String] -> String
-importedModule [_, moduleName] = moduleName
-importedModule [_, _, moduleName, _, _] = moduleName
-importedModule _ = ""
 
 getModuleName :: FileContent -> String
 getModuleName fileContent = let moduleLine = fileContent =~ "(module\\s+.*\\s+.*)" :: String

--- a/test/Arion/TypesSpec.hs
+++ b/test/Arion/TypesSpec.hs
@@ -39,9 +39,9 @@ spec = do
                                 \why\n\
                           \)\n\
                           \import Module1\n\
-                          \import Another.Module\n\
+                          \import   Another.Module\n\
                           \import Yet.Another.Module\n"
-            let expected = SourceFile { 
+            let expected = SourceFile {
                                 sourceFilePath = "mydir/Source.hs",
                                 moduleName = "Source",
                                 importedModules = ["Module1", "Another.Module", "Yet.Another.Module"]


### PR DESCRIPTION
This is just a quick patch. Ideally there'd be no actual code in Types.hs, just types.

at some point you may want to think about using something slightly more robust than regexes to parse this (like the GHC api.) For instance,

```
important arg = arg * 2
```

will currently have weird effects, I think.
