### PR TITLE
Compilation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.html
 .cabal-sandbox
 cabal.sandbox.config
+.stack-work

--- a/arion.cabal
+++ b/arion.cabal
@@ -29,8 +29,7 @@ executable arion
                        safe,
                        process >=1.2.0.0,
                        directory,
-                       transformers,
-                       time == 1.5.0.1
+                       transformers
   other-modules:       Arion.Runner,
                        Arion.Types,
                        Arion.EventProcessor,

--- a/arion.cabal
+++ b/arion.cabal
@@ -29,7 +29,8 @@ executable arion
                        safe,
                        process >=1.2.0.0,
                        directory,
-                       transformers
+                       transformers,
+                       time == 1.5.0.1
   other-modules:       Arion.Runner,
                        Arion.Types,
                        Arion.EventProcessor,

--- a/src/Arion/EventProcessor.hs
+++ b/src/Arion/EventProcessor.hs
@@ -9,15 +9,19 @@ import           Data.List                 (isSuffixOf, isInfixOf)
 import           Data.List                 (nub)
 import qualified Data.Map                  as M
 import           Data.Maybe                (fromMaybe)
+import           Data.Text                 (pack)
+import           Data.Time.Clock           (UTCTime)
 import           Filesystem.Path           (FilePath)
-import           Filesystem.Path.CurrentOS (encodeString)
 import           Prelude                   hiding (FilePath)
+import           Filesystem.Path.CurrentOS (encodeString, fromText)
 import           System.FSNotify           (Event (..))
 
+toPath :: String -> FilePath
+toPath = fromText . pack
 
-
-respondToEvent (Modified filePath time) = Just (filePath,time)
-respondToEvent (Added filePath time) = Just (filePath,time)
+respondToEvent :: Event -> Maybe (FilePath, UTCTime)
+respondToEvent (Modified filePath time) = Just (toPath filePath, time)
+respondToEvent (Added    filePath time) = Just (toPath filePath, time)
 respondToEvent _ = Nothing
 
 processEvent :: M.Map String [TestFile] -> String -> String -> (FilePath, t) -> [Command]

--- a/src/Arion/EventProcessor.hs
+++ b/src/Arion/EventProcessor.hs
@@ -9,19 +9,13 @@ import           Data.List                 (isSuffixOf, isInfixOf)
 import           Data.List                 (nub)
 import qualified Data.Map                  as M
 import           Data.Maybe                (fromMaybe)
-import           Data.Text                 (pack)
-import           Data.Time.Clock           (UTCTime)
 import           Filesystem.Path           (FilePath)
+import           Filesystem.Path.CurrentOS (encodeString, decodeString)
 import           Prelude                   hiding (FilePath)
-import           Filesystem.Path.CurrentOS (encodeString, fromText)
 import           System.FSNotify           (Event (..))
 
-toPath :: String -> FilePath
-toPath = fromText . pack
-
-respondToEvent :: Event -> Maybe (FilePath, UTCTime)
-respondToEvent (Modified filePath time) = Just (toPath filePath, time)
-respondToEvent (Added    filePath time) = Just (toPath filePath, time)
+respondToEvent (Modified filePath time) = Just (decodeString filePath, time)
+respondToEvent (Added    filePath time) = Just (decodeString filePath, time)
 respondToEvent _ = Nothing
 
 processEvent :: M.Map String [TestFile] -> String -> String -> (FilePath, t) -> [Command]

--- a/src/Arion/Runner.hs
+++ b/src/Arion/Runner.hs
@@ -54,7 +54,7 @@ startWatching path sourceFolder testFolder manager = do
 
   lock <- newEmptyMVar
   inProgress <- newIORef Map.empty
-  _ <- watchTree manager (fromText $ pack path) (const True)
+  _ <- watchTree manager path (const True)
        (eventHandler lock inProgress (processEvent sourceToTestFileMap sourceFolder testFolder) . respondToEvent)
   forever $ threadDelay maxBound
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,35 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-5.3
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
I was getting the following compile error, and figured it was a simple fix. Looks like `watchTree`, coming from `System.FSNotify`, expects the `FilePath` from `IO`. In contrast, your `respondToEvent` receives an IO.FilePath and needs to convert it to a Filesystem.Path FilePath to be processed by the `eventHandler`.

I added a stack.yaml as well, just to get the ball rolling on this.

```
Configuring arion-0.1.0.8...
Building arion-0.1.0.8...
Preprocessing executable 'arion' for arion-0.1.0.8...
[1 of 6] Compiling Arion.Types      ( src/Arion/Types.hs, dist/build/arion/arion-tmp/Arion/Types.o )
[2 of 6] Compiling Arion.Utilities  ( src/Arion/Utilities.hs, dist/build/arion/arion-tmp/Arion/Utilities.o )
[3 of 6] Compiling Arion.Help       ( src/Arion/Help.hs, dist/build/arion/arion-tmp/Arion/Help.o )
[4 of 6] Compiling Arion.EventProcessor ( src/Arion/EventProcessor.hs, dist/build/arion/arion-tmp/Arion/EventProcessor.o )
[5 of 6] Compiling Arion.Runner     ( src/Arion/Runner.hs, dist/build/arion/arion-tmp/Arion/Runner.o )

src/Arion/Runner.hs:46:27:
    Couldn't match type ‘system-filepath-0.4.13.4:Filesystem.Path.Internal.FilePath’
                   with ‘[Char]’
    Expected type: FilePath
      Actual type: system-filepath-0.4.13.4:Filesystem.Path.Internal.FilePath
    In the second argument of ‘watchTree’, namely
      ‘(fromText $ pack path)’
    In a stmt of a 'do' block:
      _ <- watchTree
             manager
             (fromText $ pack path)
             (const True)
             (eventHandler
                lock
                inProgress
                (processEvent sourceToTestFileMap sourceFolder testFolder)
              . respondToEvent)
    In the expression:
      do { sourceFiles <- mapM
                            (\ x -> uncurry toSourceFile <$> filePathAndContent x)
                          =<< findHaskellFiles sourceFolder;
           testFiles <- mapM
                          (\ x -> uncurry toTestFile <$> filePathAndContent x)
                        =<< findHaskellFiles testFolder;
           let sourceToTestFileMap = associate sourceFiles testFiles;
           lock <- newEmptyMVar;
           .... }

src/Arion/Runner.hs:47:99:
    Couldn't match type ‘[Char]’
                   with ‘system-filepath-0.4.13.4:Filesystem.Path.Internal.FilePath’
    Expected type: fsnotify-0.2.1:System.FSNotify.Types.Event
                   -> Maybe
                        (system-filepath-0.4.13.4:Filesystem.Path.Internal.FilePath,
                         time-1.5.0.1:Data.Time.Clock.UTC.UTCTime)
      Actual type: fsnotify-0.2.1:System.FSNotify.Types.Event
                   -> Maybe (FilePath, time-1.5.0.1:Data.Time.Clock.UTC.UTCTime)
    In the second argument of ‘(.)’, namely ‘respondToEvent’
    In the fourth argument of ‘watchTree’, namely
      ‘(eventHandler
          lock
          inProgress
          (processEvent sourceToTestFileMap sourceFolder testFolder)
        . respondToEvent)’
```
